### PR TITLE
VERSION -> Version (changed in thockin/go-build-template)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,6 +16,6 @@ limitations under the License.
 
 package version
 
-// VERSION is the app-global version string, which should be substituted with a
+// Version is the app-global version string, which should be substituted with a
 // real value during build.
-var VERSION = "UNKNOWN"
+var Version = "UNKNOWN"


### PR DESCRIPTION
Missed this commit when getting the current https://github.com/thockin/go-build-template/commit/ae46ecc7eba795020d40a470f947efdf9b90dbde