### PR TITLE
masq daemon crashes on bad config

### DIFF
--- a/cmd/ip-masq-agent-v2/ip-masq-agent.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent.go
@@ -150,34 +150,34 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	m := NewMasqDaemon(c)
-	m.Run()
+	err := m.Run()
+
+	if err != nil {
+		glog.Fatalf("the daemon encountered an error: %v", err)
+	}
 }
 
 // Run ...
-func (m *MasqDaemon) Run() {
+func (m *MasqDaemon) Run() error {
 	// Periodically resync to reconfigure or heal from any rule decay
 	for {
-		func() {
-			defer time.Sleep(time.Duration(*resyncInterval) * time.Second)
-			// resync config
-			err := m.osSyncConfig()
-			if err != nil {
-				glog.Errorf("error syncing configuration: %v", err)
-				return
-			}
-			// resync rules
-			err = m.syncMasqRules()
-			if err != nil {
-				glog.Errorf("error syncing masquerade rules: %v", err)
-				return
-			}
-			// resync ipv6 rules
-			err = m.syncMasqRulesIPv6()
-			if err != nil {
-				glog.Errorf("error syncing masquerade rules for ipv6: %v", err)
-				return
-			}
-		}()
+		// resync config
+		err := m.osSyncConfig()
+		if err != nil {
+			return fmt.Errorf("error syncing configuration: %w", err)
+		}
+		// resync rules
+		err = m.syncMasqRules()
+		if err != nil {
+			return fmt.Errorf("error syncing masquerade rules: %w", err)
+		}
+		// resync ipv6 rules
+		err = m.syncMasqRulesIPv6()
+		if err != nil {
+			return fmt.Errorf("error syncing masquerade rules for ipv6: %w", err)
+		}
+
+		time.Sleep(time.Duration(*resyncInterval) * time.Second)
 	}
 }
 

--- a/cmd/ip-masq-agent-v2/ip-masq-agent.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent.go
@@ -225,6 +225,11 @@ func (m *MasqDaemon) syncConfig(fs fakefs.FileSystem) error {
 				return fmt.Errorf("failed to unmarshal config file %q, error: %w", file.Name(), err)
 			}
 
+			err = newConfig.validate()
+			if err != nil {
+				return fmt.Errorf("config %s is invalid: %w", file.Name(), err)
+			}
+
 			c.merge(&newConfig)
 
 			configAdded = true
@@ -235,12 +240,6 @@ func (m *MasqDaemon) syncConfig(fs fakefs.FileSystem) error {
 		// no valid config files found, use defaults
 		c = DefaultMasqConfig()
 		glog.V(2).Infof("no valid config files found at %q, using default values", configPath)
-	}
-
-	// validate configuration
-	err = c.validate()
-	if err != nil {
-		return fmt.Errorf("config is invalid, error: %w", err)
 	}
 
 	// apply new config

--- a/cmd/ip-masq-agent-v2/ip-masq-agent.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent.go
@@ -227,7 +227,7 @@ func (m *MasqDaemon) syncConfig(fs fakefs.FileSystem) error {
 
 			err = newConfig.validate()
 			if err != nil {
-				return fmt.Errorf("config %s is invalid: %w", file.Name(), err)
+				return fmt.Errorf("config file %q is invalid: %w", file.Name(), err)
 			}
 
 			c.merge(&newConfig)

--- a/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
@@ -315,7 +315,7 @@ nonMasqueradeCIDRs:
 			Content: `
 nonMasqueradeCIDRs:
   - 
-`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config file \"ip-masq-config-0\" is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"single invalid yaml file, mix valid and empty values",
 		fakefs.StringFS{Files: []fakefs.File{{
@@ -328,7 +328,7 @@ nonMasqueradeCIDRs:
   - fd88:1234::/80
 masqLinkLocal: true
 masqLinkLocalIPv6: true
-`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config file \"ip-masq-config-0\" is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"single invalid yaml file, whitespace",
 		fakefs.StringFS{Files: []fakefs.File{{
@@ -337,7 +337,7 @@ masqLinkLocalIPv6: true
 			Content: `
 nonMasqueradeCIDRs:
   - ""
-`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config file \"ip-masq-config-0\" is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"multiple yaml configs, one bad config - empty CIDR value",
 		fakefs.StringFS{Files: []fakefs.File{{
@@ -355,7 +355,7 @@ nonMasqueradeCIDRs:
   - 192.168.0.0/24
 masqLinkLocal: true
 masqLinkLocalIPv6: true
-`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config file \"ip-masq-config-0\" is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"multiple json files, but one has empty CIDR", fakefs.StringFS{Files: []fakefs.File{{
 		Name: configFilePrefix + "-config-0",
@@ -376,7 +376,7 @@ masqLinkLocalIPv6: true
 	  "masqLinkLocalIPv6": true
 	}
 	`},
-	}}, fmt.Errorf("config ip-masq-config-1 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+	}}, fmt.Errorf("config file \"ip-masq-config-1 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 }
 
 // tests MasqDaemon.syncConfig

--- a/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
@@ -376,7 +376,7 @@ masqLinkLocalIPv6: true
 	  "masqLinkLocalIPv6": true
 	}
 	`},
-	}}, fmt.Errorf("config file \"ip-masq-config-1 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+	}}, fmt.Errorf("config file \"ip-masq-config-1\" is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 }
 
 // tests MasqDaemon.syncConfig

--- a/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
@@ -307,6 +307,55 @@ nonMasqueradeCIDRs:
 		}
 		`},
 	}}, fmt.Errorf("failed to read config file \"ip-masq-config-0\", error: open " + filepath.Join(configPath, configFilePrefix+"-config-0") + ": errno 2"), NewMasqConfigNoReservedRanges()},
+
+	{"single invalid yaml file, empty entry",
+		fakefs.StringFS{Files: []fakefs.File{{
+			Name: configFilePrefix + "-config-0",
+			Path: configPath,
+			Content: `
+nonMasqueradeCIDRs:
+  - 
+`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+
+{"single invalid yaml file, mix valid and empty values",
+		fakefs.StringFS{Files: []fakefs.File{{
+			Name: configFilePrefix + "-config-0",
+			Path: configPath,
+			Content: `
+nonMasqueradeCIDRs:
+  - 192.168.0.0/24
+  - 
+  - fd88:1234::/80
+masqLinkLocal: true
+masqLinkLocalIPv6: true
+`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+
+	{"single invalid yaml file, whitespace",
+		fakefs.StringFS{Files: []fakefs.File{{
+			Name: configFilePrefix + "-config-0",
+			Path: configPath,
+			Content: `
+nonMasqueradeCIDRs:
+  - ""
+`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+
+	{"multiple yaml configs, one bad config - empty CIDR value",
+		fakefs.StringFS{Files: []fakefs.File{{
+			Name: configFilePrefix + "-config-0",
+			Path: configPath,
+			Content: `
+nonMasqueradeCIDRs:
+  -
+`},
+		{
+			Name: configFilePrefix + "-config-1",
+			Path: configPath,
+			Content: `
+nonMasqueradeCIDRs:
+  - 192.168.0.0/24
+masqLinkLocal: true
+masqLinkLocalIPv6: true
+`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 }
 
 // tests MasqDaemon.syncConfig

--- a/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
@@ -357,26 +357,26 @@ masqLinkLocal: true
 masqLinkLocalIPv6: true
 `}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
-{"multiple json files, but one has empty CIDR", fakefs.StringFS{Files: []fakefs.File{{
-	Name: configFilePrefix + "-config-0",
-	Path: configPath,
-	Content: `
+	{"multiple json files, but one has empty CIDR", fakefs.StringFS{Files: []fakefs.File{{
+		Name: configFilePrefix + "-config-0",
+		Path: configPath,
+		Content: `
 	{
 	  "nonMasqueradeCIDRs": ["111.254.0.0/15", "8.0.0.0/8"],
 	  "masqLinkLocal": false,
 	  "masqLinkLocalIPv6": false
 	}
 	`}, {
-	Name: configFilePrefix + "-config-1",
-	Path: configPath,
-	Content: `
+		Name: configFilePrefix + "-config-1",
+		Path: configPath,
+		Content: `
 	{
 	  "nonMasqueradeCIDRs": [null, "172.168.0.0/16"],
 	  "masqLinkLocal": true,
 	  "masqLinkLocalIPv6": true
 	}
 	`},
-}}, fmt.Errorf("config ip-masq-config-1 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+	}}, fmt.Errorf("config ip-masq-config-1 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 }
 
 // tests MasqDaemon.syncConfig

--- a/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
@@ -317,7 +317,7 @@ nonMasqueradeCIDRs:
   - 
 `}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
-{"single invalid yaml file, mix valid and empty values",
+	{"single invalid yaml file, mix valid and empty values",
 		fakefs.StringFS{Files: []fakefs.File{{
 			Name: configFilePrefix + "-config-0",
 			Path: configPath,
@@ -347,10 +347,10 @@ nonMasqueradeCIDRs:
 nonMasqueradeCIDRs:
   -
 `},
-		{
-			Name: configFilePrefix + "-config-1",
-			Path: configPath,
-			Content: `
+			{
+				Name: configFilePrefix + "-config-1",
+				Path: configPath,
+				Content: `
 nonMasqueradeCIDRs:
   - 192.168.0.0/24
 masqLinkLocal: true

--- a/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent_test.go
@@ -315,7 +315,7 @@ nonMasqueradeCIDRs:
 			Content: `
 nonMasqueradeCIDRs:
   - 
-`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"single invalid yaml file, mix valid and empty values",
 		fakefs.StringFS{Files: []fakefs.File{{
@@ -328,7 +328,7 @@ nonMasqueradeCIDRs:
   - fd88:1234::/80
 masqLinkLocal: true
 masqLinkLocalIPv6: true
-`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"single invalid yaml file, whitespace",
 		fakefs.StringFS{Files: []fakefs.File{{
@@ -337,7 +337,7 @@ masqLinkLocalIPv6: true
 			Content: `
 nonMasqueradeCIDRs:
   - ""
-`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 
 	{"multiple yaml configs, one bad config - empty CIDR value",
 		fakefs.StringFS{Files: []fakefs.File{{
@@ -355,7 +355,28 @@ nonMasqueradeCIDRs:
   - 192.168.0.0/24
 masqLinkLocal: true
 masqLinkLocalIPv6: true
-`}}}, fmt.Errorf("config is invalid, error: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+`}}}, fmt.Errorf("config ip-masq-config-0 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
+
+{"multiple json files, but one has empty CIDR", fakefs.StringFS{Files: []fakefs.File{{
+	Name: configFilePrefix + "-config-0",
+	Path: configPath,
+	Content: `
+	{
+	  "nonMasqueradeCIDRs": ["111.254.0.0/15", "8.0.0.0/8"],
+	  "masqLinkLocal": false,
+	  "masqLinkLocalIPv6": false
+	}
+	`}, {
+	Name: configFilePrefix + "-config-1",
+	Path: configPath,
+	Content: `
+	{
+	  "nonMasqueradeCIDRs": [null, "172.168.0.0/16"],
+	  "masqLinkLocal": true,
+	  "masqLinkLocalIPv6": true
+	}
+	`},
+}}, fmt.Errorf("config ip-masq-config-1 is invalid: CIDR \"\" could not be parsed, invalid CIDR address: "), NewMasqConfigNoReservedRanges()},
 }
 
 // tests MasqDaemon.syncConfig


### PR DESCRIPTION
The main loop of the masq daemon now returns an error in order to crash the program if an error is encountered. Crashing will make the presence of a problem more obvious in a cluster by placing the pod in a CrashLoopBackOff state.

The glog logger's `Fatalf` will log the error message returned from the daemon and then call `os.Exit(255)` from inside `main`.