### PR TITLE
[Donot Merge] Feature/enable mcr workflow

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -1,0 +1,71 @@
+name: Building and pushing mcr
+on: [workflow_dispatch]
+
+permissions:
+      id-token: write
+      contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args:
+            -v
+            --max-same-issues 10
+            --disable-all
+            --exclude-use-default=false
+            -E asciicheck
+            -E deadcode
+            -E errcheck
+            -E forcetypeassert
+            -E gocritic
+            -E gofmt
+            -E goimports
+            -E gosimple
+            -E govet
+            -E ineffassign
+            -E misspell
+            -E staticcheck
+            -E structcheck
+            -E typecheck
+            -E unused
+            -E varcheck
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: |
+          make build
+        name: Build
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_depth: 10
+          path: ./CHANGELOG.md
+      - name: Display output
+        run: |
+           echo "Version: ${{ steps.changelog_reader.outputs.version }}"
+           echo "Changes: ${{ steps.changelog_reader.outputs.changes }}"
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: 'Run Azure CLI commands'
+        run: |
+          docker build -f #what ever is the mechanism for this repo .
+          # docker tag public/aks/periscope ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasqagent:${{ steps.changelog_reader.outputs.version }}
+          az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
+          # docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasagent:${{ steps.changelog_reader.outputs.version }}
+          echo "acr push done"
+
+      

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,71 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master, master* ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '37 13 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/main.yaml/badge.svg)](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/main.yaml)
 [![CodeQL](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/codeql-analysis.yaml/badge.svg)](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/codeql-analysis.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/azure/ip-masq-agent-v2)](https://goreportcard.com/report/github.com/azure/ip-masq-agent-v2)
+[![GoDoc](https://godoc.org/github.com/azure/ip-masq-agent-v2?status.svg)](https://pkg.go.dev/github.com/azure/ip-masq-agent-v2)
 
 Based on the original [ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent), v2 aims to solve more specific networking cases, allow for more configuration options, and improve observability. This includes:
 * Merging configuration from multiple sources

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ip-masq-agent-v2
 
+[![CI](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/main.yaml/badge.svg)](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/main.yaml)
+[![CodeQL](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/codeql-analysis.yaml/badge.svg)](https://github.com/Azure/ip-masq-agent-v2/actions/workflows/codeql-analysis.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/azure/ip-masq-agent-v2)](https://goreportcard.com/report/github.com/azure/ip-masq-agent-v2)
+
 Based on the original [ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent), v2 aims to solve more specific networking cases, allow for more configuration options, and improve observability. This includes:
 * Merging configuration from multiple sources
 * Support for health checking


### PR DESCRIPTION
Opening this PR for idea and possibly this could be worked as the PR for IPMasqAgent MCr image publish.

This is created for e-2-e mcr publishing via GitHub workflow, which leads to no more stepping out this repo for image publishing and more efficiency.

Please note: (Before we merge this)

* We have done right `web hook` changes for new `acr`
* and all the required env vars are populated. (I can help you with that) 

Thanks, cc: @mattstam , @paulgmiller 