### PR TITLE
Add workflow for ACR/MCR image build and publish.

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -63,7 +63,7 @@ jobs:
       - name: 'Run Azure CLI commands'
         run: |
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ VERSION=${{ steps.changelog_reader.outputs.version }} make push
+          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=${{ steps.changelog_reader.outputs.version }} make push
           #docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           #docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           echo "acr push done"

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -65,7 +65,7 @@ jobs:
           make build
           # docker tag public/aks/periscope ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasqagent:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          # docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasagent:${{ steps.changelog_reader.outputs.version }}
+          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasagent:${{ steps.changelog_reader.outputs.version }}
           echo "acr push done"
 
       

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -62,7 +62,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: 'Run Azure CLI commands'
         run: |
-          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }} VERSION={{ steps.changelog_reader.outputs.version }} make build
+          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }} VERSION=${{ steps.changelog_reader.outputs.version }} make build
           docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2${{ steps.changelog_reader.outputs.version }}

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -65,7 +65,7 @@ jobs:
           REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }} VERSION=${{ steps.changelog_reader.outputs.version }} make build
           docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2${{ steps.changelog_reader.outputs.version }}
+          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           echo "acr push done"
 
       

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -62,7 +62,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: 'Run Azure CLI commands'
         run: |
-          make build
+          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }} VERSION={{ steps.changelog_reader.outputs.version }} make build
           docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2${{ steps.changelog_reader.outputs.version }}

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -64,8 +64,6 @@ jobs:
         run: |
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=${{ steps.changelog_reader.outputs.version }} make push
-          #docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
-          #docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
-          echo "acr push done"
+          echo "ACR push done"
 
       

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -63,9 +63,9 @@ jobs:
       - name: 'Run Azure CLI commands'
         run: |
           make build
-          # docker tag public/aks/periscope ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasqagent:${{ steps.changelog_reader.outputs.version }}
+          docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasagent:${{ steps.changelog_reader.outputs.version }}
+          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2${{ steps.changelog_reader.outputs.version }}
           echo "acr push done"
 
       

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -62,10 +62,10 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: 'Run Azure CLI commands'
         run: |
-          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }} VERSION=${{ steps.changelog_reader.outputs.version }} make build
-          docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
+          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ VERSION=${{ steps.changelog_reader.outputs.version }} make push
+          #docker tag public/aks/ip-masq-agent-v2 ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
+          #docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ip-masq-agent-v2:${{ steps.changelog_reader.outputs.version }}
           echo "acr push done"
 
       

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -62,7 +62,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: 'Run Azure CLI commands'
         run: |
-          docker build -f #what ever is the mechanism for this repo .
+          make build
           # docker tag public/aks/periscope ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasqagent:${{ steps.changelog_reader.outputs.version }}
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           # docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/ipmasagent:${{ steps.changelog_reader.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ifeq ($(ARCH),ppc64le)
     BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-ppc64le:buster-v1.7.0
 endif
 
-TAG := $(VERSION)__$(OS)_$(ARCH)
+TAG := $(VERSION)
 
 BUILD_IMAGE ?= golang:1.17-alpine
 


### PR DESCRIPTION
This will set up Github action ACR publish (which eventually gets to MCR). Using @Tatsinnit's [PR](https://github.com/Azure/aks-periscope/pull/151) as example.

Build has been tested in fork: https://github.com/mattstam/ip-masq-agent-v2/runs/5415657376?check_suite_focus=true

Thanks to @Tatsinnit and @peterbom for organizing this flow and helping with set up 🙏