### PR TITLE
Update publish action to support semantic versioning

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -63,7 +63,7 @@ jobs:
       - name: 'Run Azure CLI commands'
         run: |
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=${{ steps.changelog_reader.outputs.version }} make push
+          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=v${{ steps.changelog_reader.outputs.version }} make push
           echo "ACR push done"
 
       


### PR DESCRIPTION
> 💡☕️ oh, a quick note: this versioning might not play nice with the release (publish mcr workflow) because of the change log action, so I would recommend if you want to keep “v” you could add that in your publishing tag file.
> 
> * **quickest solution** will be here add “v” as character before the versioning for “VERSION” variable: https://github.com/Azure/ip-masq-agent-v2/blob/master/.github/workflows/build-publish-mcr.yml#L66
> * Change this line `66` from `REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=${{ steps.changelog_reader.outputs.version }} make push` to `REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=v${{ steps.changelog_reader.outputs.version }} make push`
> * Changed bit is: `VERSION=v${{ steps.changelog_reader.outputs.version }} make push` added `v` so keep change-log as without `v`.
> 
> FYI and Cc: @peterbom in case I am not around.

Thank you @Tatsinnit for this! 🙏 