### PR TITLE
Update usage examples, README, and CHANGELOG formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ cmd/_test_output
 *.test
 *.coverprofile
 **/junit.xml
+
+# Mac
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.1.2]
 
-* Update usage examples, README, and remove commit race from CHANGELOG
+* Update usage examples, README, and CHANGELOG formatting
 
 ## [0.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,33 @@
 # Change Log
 
+## [0.1.2]
+
+* Update usage examples, README, and remove commit race from CHANGELOG
+
 ## [0.1.1]
 
-* Update Kubernetes to v1.23.0 from v1.13.0-alpha by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/31
-* Migrate to semantic versioning by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/32
-* Update publish action to support semantic versioning by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/33
-* Remove version prefix in CHANGElOG by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/34
-
-**Full Changelog**: https://github.com/Azure/ip-masq-agent-v2/commits/v0.1.1
+* Update Kubernetes to v1.23.0 from v1.13.0-alpha
+* Migrate to semantic versioning
+* Update publish action to support semantic versioning
+* Remove version prefix in CHANGELOG
 
 ## [0.1.0]
 
-* Update README for v2 goals by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/1
-* Setup go modules by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/5
-* Add editor files and future test output to gitignore by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/6
-* Azure repo setup, remove obsolete files by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/7
-* Update to the current thockin/go-build-template by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/8
-* VERSION -> Version (changed in thockin/go-build-template) by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/9
-* Config resync interval as a flag by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/11
-* Merge data from multiple config files by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/10
-* v2 for image name by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/14
-* Update to the latest OSS guidelines by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/13
-* Setup github actions by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/12
-* Add ci-pipeline for this repo. by @Tatsinnit in https://github.com/Azure/ip-masq-agent-v2/pull/15
-* Merge CI actions, use make to build and test by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/16
-* Enable Code QL analysis by @Tatsinnit in https://github.com/Azure/ip-masq-agent-v2/pull/17
-* Add quality visibility to the repo. by @Tatsinnit in https://github.com/Azure/ip-masq-agent-v2/pull/18
-* Add go reference to the repo. by @Tatsinnit in https://github.com/Azure/ip-masq-agent-v2/pull/19
-* masq daemon crashes on bad config by @tyler-lloyd in https://github.com/Azure/ip-masq-agent-v2/pull/20
-* Update README with new usage instructions by @mattstam in https://github.com/Azure/ip-masq-agent-v2/pull/21
-
-## New Contributors
-* @mattstam made their first contribution in https://github.com/Azure/ip-masq-agent-v2/pull/1
-* @Tatsinnit made their first contribution in https://github.com/Azure/ip-masq-agent-v2/pull/15
-* @tyler-lloyd made their first contribution in https://github.com/Azure/ip-masq-agent-v2/pull/20
-
-**Full Changelog**: https://github.com/Azure/ip-masq-agent-v2/commits/v0.1.0
+* Update README for v2 goals
+* Setup go modules
+* Add editor files and future test output to gitignore
+* Azure repo setup, remove obsolete files
+* Update to the current thockin/go-build-template
+* VERSION -> Version (changed in thockin/go-build-template)
+* Config resync interval as a flag
+* Merge data from multiple config files
+* v2 for image name
+* Update to the latest OSS guidelines
+* Setup github actions
+* Add ci-pipeline for this repo
+* Merge CI actions, use make to build and test
+* Enable Code QL analysis
+* Add quality visibility to the repo
+* Add go reference to the repo
+* masq daemon crashes on bad config
+* Update README with new usage instructions

--- a/examples/config-cloud.yaml
+++ b/examples/config-cloud.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ip-masq-agent-config-cloud
+  name: ip-masq-agent-config-reconciled
   namespace: default
   labels:
     component: ip-masq-agent
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 data:
-  ip-masq-agent-cloud: |-
+  ip-masq-agent-reconciled: |-
     nonMasqueradeCIDRs:
       - 1.0.0.0/8
       - 2.2.0.0/16

--- a/examples/ip-masq-agent.yaml
+++ b/examples/ip-masq-agent.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: docker.io/mattstam/ip-masq-agent:v2.6.1-11-gabd856e-dirty__linux_amd64
+        image: mcr.microsoft.com/aks/ip-masq-agent-v2:v0.1.1
         imagePullPolicy: Always
         args:
           - --v=2
@@ -39,17 +39,17 @@ spec:
           sources:
             # Note these ConfigMaps must be created in the same namespace as the daemonset
             - configMap:
-                name: ip-masq-agent-config
-                optional: true
-                items:
-                  - key: ip-masq-agent
-                    path: ip-masq-agent
-                    mode: 444
+              name: ip-masq-agent-config
+              optional: true
+              items:
+                - key: ip-masq-agent
+                  path: ip-masq-agent
+                  mode: 444
             - configMap:
-                name: ip-masq-agent-config-cloud
-                optional: true
-                items:
-                  # Avoiding duplicate paths
-                  - key: ip-masq-agent-cloud
-                    path: ip-masq-agent-cloud
-                    mode: 444
+              name: ip-masq-agent-config-reconciled
+              optional: true
+              items:
+                # Avoiding duplicate paths
+                - key: ip-masq-agent-reconciled
+                  path: ip-masq-agent-reconciled
+                  mode: 444


### PR DESCRIPTION
Bunch of miscellaneous changes:

* Reference MCR image in examples
* Switch to `-reconciled` since it matches what cloud provider will likely use for maximum clarity.
* Add some missing content in README
* CHANGELOG references PR number, which you would have to know before hand. Keep formatting on releases page but removing that content from CHANGELOG so it's practical to update once per PR.
