### PR TITLE
Add CI for multi-arch builds

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -63,7 +63,7 @@ jobs:
       - name: 'Run Azure CLI commands'
         run: |
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=v${{ steps.changelog_reader.outputs.version }} make push
+          REGISTRY=${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks VERSION=v${{ steps.changelog_reader.outputs.version }} make all-manifest
           echo "ACR push done"
 
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.1.2]
 
 * Update usage examples, README, and CHANGELOG formatting
+* Add CI for multi-arch builds
 
 ## [0.1.1]
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BINS := ip-masq-agent-v2
 ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x windows/amd64
 
 # Where to push the docker images.
-REGISTRY ?= mattstamcr.azurecr.io/testall/aks
+REGISTRY ?= gcr.io/k8s-staging-networking
 
 # This version-strategy uses git tags to set the version string
 VERSION ?= $(shell git describe --tags --always --dirty)
@@ -121,7 +121,7 @@ all-container: $(addprefix container-, $(subst /,_, $(ALL_PLATFORMS)))
 all-push: # @HELP pushes containers for all platforms to the defined registry
 all-push: $(addprefix push-, $(subst /,_, $(ALL_PLATFORMS)))
 
-all-manifest: # @HELP manifest
+all-manifest: # @HELP creates a docker manifest for all platforms (for multi-arch)
 all-manifest: $(addprefix manifest-, $(subst /,_, $(ALL_PLATFORMS)))
 
 # The following structure defeats Go's (intentional) behavior to always touch
@@ -254,22 +254,13 @@ push: container
 	done
 	@echo
 
-manifest: # @HELP manifest the container for one platform ($OS/$ARCH) to the defined registry
+manifest: # @HELP updates and pushes a manifest tag, which can contain multiple ($OS/$ARCH)
 manifest: push
-	@for bin in $(BINS); do              \
+	@for bin in $(BINS); do              					\
 	    docker manifest create $(REGISTRY)/$$bin:$(VERSION) \
-	    --amend "$(REGISTRY)/$$bin:$(TAG)"; \
+	    --amend "$(REGISTRY)/$$bin:$(TAG)";			 		\
 	    docker manifest push $(REGISTRY)/$$bin:$(VERSION);  \
 	done
-#	@echo $(BINS);
-#	@echo $(REGISTRY)/$(BINS):$(VERSION)
-#	for bin in $(BINS); do    						        \
-#  	    echo "container: $(REGISTRY)/$$bin:$(VERSION)"; 	\
-#	    docker manifest create $(REGISTRY)/$$bin:$(VERSION);\
-##	    --amend "$(REGISTRY)/$$bin:$(TAG)"; 				\
-#
-#	    docker manifest push $(REGISTRY)/$$bin:$(VERSION)
-#	done
 	@echo
 
 version: # @HELP outputs the version string


### PR DESCRIPTION
With this change, one docker manifest for multiple platforms is used when the main image tag `<registry>/<path>/<bin>:<version>`:
<img width="648" alt="image" src="https://user-images.githubusercontent.com/15695189/159344019-4632ca0e-7bfe-4ab6-8c5b-bba3ad373b21.png">

This means that the appropriate image will be used depending on the platform that pulls it, allowing for full multi-arch usage.

To use simply run `make all-manifest` create a manifest for all platforms listed in the Makefile.

(also adding IBM's arch iptables base image)