### PR TITLE
Initialize logging flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.1.3]
 
 * Remove /vendor from VCS
+* Initialize logging flags
 
 ## [0.1.2]
 

--- a/cmd/ip-masq-agent-v2/ip-masq-agent.go
+++ b/cmd/ip-masq-agent-v2/ip-masq-agent.go
@@ -137,6 +137,8 @@ func NewMasqDaemon(c *MasqConfig) *MasqDaemon {
 }
 
 func main() {
+	klog.InitFlags(nil)
+
 	flag.Parse()
 	masqChain = utiliptables.Chain(*masqChainFlag)
 


### PR DESCRIPTION
`klog` has slightly different initialization behavior from the previously used `glog`. `klog.InitFlags()` must be called at startup time to handle the verbosity flags (e.g. `--v=2`).