### PR TITLE
Switch base image to distroless-iptables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.1.4]
+
+* Switch base image to distroless-iptables
+
 ## [0.1.3]
 
 * Remove /vendor from VCS

--- a/Makefile
+++ b/Makefile
@@ -50,22 +50,9 @@ ifeq ($(INTERACTIVE), 1)
     TTY=t
 endif
 
-# Set default base image dynamically for each arch
-ifeq ($(ARCH),amd64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.7.0
-endif
-ifeq ($(ARCH),arm)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-arm:buster-v1.7.0
-endif
-ifeq ($(ARCH),arm64)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-arm64:buster-v1.7.0
-endif
-ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-ppc64le:buster-v1.7.0
-endif
-ifeq ($(ARCH),s390x)
-	BASEIMAGE?=k8s.gcr.io/build-image/debian-iptables-s390x:buster-v1.7.0
-endif
+# Use a distroless multi-arch base image, based on debian-iptables:
+# https://github.com/kubernetes/kubernetes/issues/109406#issuecomment-1195957805
+BASEIMAGE ?= k8s.gcr.io/build-image/distroless-iptables:v0.1.1
 
 TAG := $(VERSION)__$(OS)_$(ARCH)
 


### PR DESCRIPTION
Roughly the same as @rikatz's rationale:

> we need to reduce costs (and by reducing costs, reducing image size)
> we need to use something with a smaller footprint and reduce the amount of packages, and as a result the amount of CVEs in image package.
> kube-proxy exists in all nodes (unless you use a CNI that implements its features) so it is a good candidate

Same as [kube-proxy](https://github.com/kubernetes/kubernetes/pull/111060/files) and also keeping in sync with what they v1 did: https://github.com/kubernetes-sigs/ip-masq-agent/commit/cf9563a9605c65fc9d67dc8391d61bad89fc3295