### PR TITLE
Update base and builder images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.1.7]
+
+* Use go 1.20 builder image
+* Use base image registry.k8s.io/build-image/distroless-iptables:v0.2.4
+
 ## [0.1.6]
 
 * Bump golang.org/x/text from 0.3.7 to 0.3.8

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM {ARG_FROM}
+FROM --platform=$TARGETPLATFORM {ARG_FROM}
 
 # Add the platform-specific binary.
 COPY bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}


### PR DESCRIPTION
Use builder image with go 1.20 to match upstream.

Use base image registry.k8s.io/build-image/distroless-iptables:v0.2.4

Since distroless-iptables is a multi-arch image, configure the Dockerfile and Makefile to specify --platform for each target platform. This allows us to use the upstream base image from registry.k8s.io directly without building manually and pushing to a separate ACR.

This commit also removes the Windows target. Git commit history says this got added in commit b9e714d4efb2ca7df05a9a813e7d04fff382be48 "Update to the current thockin/go-build-template"
However, upstream ip-masq-agent never added the windows target, and distroless-iptables doesn't support it. We don't use ip-masq-agent on Windows, so I think it's safe to remove.

Tested the new images on both AMD64 and ARM64 nodes in an AKS overlay cluster. Verified that the cluster created successfully, ip-masq-agent was running on both AMD64 and ARM64 nodes, and the ip-masq-agent iptables rules were installed.