### PR TITLE
Bump distroless-iptables to v0.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ifeq ($(INTERACTIVE), 1)
 endif
 
 # Use a distroless base image, based on debian-iptables: https://github.com/kubernetes/release/tree/master/images/build/distroless-iptables
-BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.4.2
+BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.4.5
 
 TAG := $(VERSION)__$(OS)_$(ARCH)
 


### PR DESCRIPTION
Resolves CVE-2023-6246 and CVE-2023-6779 in the distroless-iptables base image.