### PR TITLE
Remove deprecated lint jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,6 @@ jobs:
             --disable-all
             --exclude-use-default=false
             -E asciicheck
-            -E deadcode
             -E errcheck
             -E forcetypeassert
             -E gocritic
@@ -33,10 +32,8 @@ jobs:
             -E ineffassign
             -E misspell
             -E staticcheck
-            -E structcheck
             -E typecheck
             -E unused
-            -E varcheck
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
golangci-lint v1.59.0 exits with error code 7 if there are any deprecation errors logged:
https://github.com/golangci/golangci-lint/commit/4ba2155996359eabd8800d1fbf3e3a9777c80490

There were some errors in the lint job due to use of deprecated linters:
  level=error msg="[linters_context] deadcode: This linter is fully inactivated: it will not produce any reports."
  level=error msg="[linters_context] structcheck: This linter is fully inactivated: it will not produce any reports."
  level=error msg="[linters_context] varcheck: This linter is fully inactivated: it will not produce any reports."

Fix it by removing the deprecated linters.