### PR TITLE
Use Microsoft image for Go toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.4.8
 
 TAG := $(VERSION)__$(OS)_$(ARCH)
 
-BUILD_IMAGE ?= golang:1.22-alpine
+BUILD_IMAGE ?= mcr.microsoft.com/oss/go/microsoft/golang:1.22.5-bookworm
 
 # It's necessary to set this because some environments don't link sh -> bash.
 SHELL := /usr/bin/env bash

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
Use mcr.microsoft.com/oss/go/microsoft/golang:1.22.5-bookworm as the Go build image. This avoids rate limiting pulling the alpine-based image from Docker Hub.

In Microsoft golang image, /bin/sh is not bash, so `-o pipefail` isn't available. Fix it by setting build.sh to use /bin/bash explicitly.