### PR TITLE
update change log for 1.1.6 tag release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
+## [1.1.16]
 
+* Bump golang.org/x/net to v0.36.0
+* Bump k8s.io/kubernetes to v1.31.6
+ 
 ## [1.1.15]
 
 * Bump k8s.io/apimachinery to v0.31.3


### PR DESCRIPTION
## [1.1.16]

* Bump golang.org/x/net to v0.36.0
* Bump k8s.io/kubernetes to v1.31.6

Solves 

ip-masq-agent-v2 (gobinary)

Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 0, CRITICAL: 0)

┌───────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│      Library      │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                            Title                             │
├───────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net  │ CVE-2025-22870 │ MEDIUM   │ fixed  │ v0.33.0           │ 0.36.0                           │ Matching of hosts against proxy patterns can improperly      │
│                   │                │          │        │                   │                                  │ treat an IPv6 ...                                            │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2025-22870                   │
├───────────────────┼────────────────┤          │        ├───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ k8s.io/kubernetes │ CVE-2025-0426  │          │        │ v1.31.3           │ 1.32.2, 1.31.6, 1.30.10, 1.29.14 │ k8s.io/kubernetes: kubelet: node denial of service via       │
│                   │                │          │        │                   │                                  │ kubelet checkpoint API                                       │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2025-0426                    │
├───────────────────┼────────────────┤          │        ├───────────────────┼──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib            │ CVE-2024-45336 │          │        │ 1.23.2            │ 1.22.11, 1.23.5, 1.24.0-rc.2     │ golang: net/http: net/http: sensitive headers incorrectly    │
│                   │                │          │        │                   │                                  │ sent after cross-domain redirect                             │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-45336                   │
│                   ├────────────────┤          │        │                   │                                  ├──────────────────────────────────────────────────────────────┤
│                   │ CVE-2024-45341 │          │        │                   │                                  │ golang: crypto/x509: crypto/x509: usage of IPv6 zone IDs can │
│                   │                │          │        │                   │                                  │ bypass URI name...                                           │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2024-45341                   │
│                   ├────────────────┤          │        │                   ├──────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                   │ CVE-2025-22866 │          │        │                   │ 1.22.12, 1.23.6, 1.24.0-rc.3     │ crypto/internal/nistec: golang: Timing sidechannel for P-256 │
│                   │                │          │        │                   │                                  │ on ppc64le in crypto/internal/nistec                         │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2025-22866                   │
└───────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴────────────────────────────────────